### PR TITLE
Add TestFiles Support: Enables additional files to be transfered to the VMs 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -108,10 +108,18 @@ type PreloadModule struct {
 	TimeoutAfterLoad Duration
 }
 
+// Extra test files to copy over
+type FileTransfer struct {
+	User    string
+	Local   string
+	Remote  string
+}
+
 // Artifact is for .out-of-tree.toml
 type Artifact struct {
 	Name             string
 	Type             ArtifactType
+	TestFiles	 []FileTransfer
 	SourcePath       string
 	SupportedKernels []KernelMask
 

--- a/debug.go
+++ b/debug.go
@@ -201,6 +201,15 @@ func debugHandler(kcfg config.KernelConfig, workPath, kernRegex, gdb string,
 		return
 	}
 
+	// Copy all test files to the remote machine
+	for _,f := range ka.TestFiles {
+		err = q.CopyFile(f.User,f.Local,f.Remote)
+		if err != nil {
+			log.Println("error copy err:", err, f.Local, f.Remote)
+			return
+		}
+	}
+
 	coloredRemoteFile := aurora.BgGreen(aurora.Black(remoteFile))
 	fmt.Printf("[*] build result copied to %s\n", coloredRemoteFile)
 

--- a/pew.go
+++ b/pew.go
@@ -251,6 +251,15 @@ func copyArtifactAndTest(q *qemu.System, ka config.Artifact,
 		}
 		res.Run.Ok = true
 
+		// Copy all test files to the remote machine
+		for _,f := range ka.TestFiles {
+			err = q.CopyFile(f.User,f.Local,f.Remote)
+			if err != nil {
+				log.Println("error copy err:", err, f.Local, f.Remote)
+				return
+			}
+		}
+
 		res.Test.Output, err = testKernelModule(q, ka, remoteTest)
 		if err != nil {
 			log.Println(res.Test.Output, err)


### PR DESCRIPTION
This PR adds a `FileTransfer` struct, that contains the user, local path, and remote path for a file transfer:

```
type FileTransfer struct {
	User    string
	Local   string
	Remote  string
}
```

And adds a field `TestFiles` to the Artifact struct, so that multiple files can be defined in the configuration and transferred to test VMs. Example configuration:

```
# install a utility into the VM
[[test_files]]
user = "root"
local = "./db"
remote = "/usr/bin/db"

# Bring along a test RSA key
[[test_files]]
user = "root"
local = "./db_rsa"
remote = "/tmp/db_rsa"

[[supported_kernels]]
distro_type = "Ubuntu"
distro_release = "16.04"
release_mask = "4[.]4[.]0-70-.*"
```

